### PR TITLE
Fix submodule syncronization

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: fireeye/capa
+        token: ${{ secrets.CAPA_TOKEN }}
     - name: Checkout capa-testfiles
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Add token to checkout in GitHub action. GitHub doesn't allow to push if you haven't use the same authentication to checkout the changes. Related to https://github.com/fireeye/capa-rules/pull/42.