### PR TITLE
add feature snapshot manifest.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.idb
 *.i64
 *.json
+!fixtures/snapshots/features/manifest.json
 *.txt
 # IDA Pro intermediate database files
 *.nam

--- a/fixtures/snapshots/features/manifest.json
+++ b/fixtures/snapshots/features/manifest.json
@@ -1,0 +1,49 @@
+{
+    "version": 1,
+    "description": "Feature snapshot fixtures. See README.md.",
+    "snapshots": [
+        {
+            "name": "pma01-01-dll",
+            "sample": "Practical Malware Analysis Lab 01-01.dll_",
+            "freeze": "pma01-01-dll.frz",
+            "explanation": "Smallest PE 32-bit DLL in the corpus. Fast baseline for the PE DLL path through the viv backend (exports, imports, small function count).",
+            "generated_at_commit": "cd07bd230e831cb216450aec98859ae1dc6b16ff"
+        },
+        {
+            "name": "mimikatz-exe",
+            "sample": "mimikatz.exe_",
+            "freeze": "mimikatz-exe.frz",
+            "explanation": "Well-known PE 32-bit EXE with a wide variety of features. Exercises the PE EXE path through viv against a realistic, feature-dense sample.",
+            "generated_at_commit": "cd07bd230e831cb216450aec98859ae1dc6b16ff"
+        },
+        {
+            "name": "pma21-01-exe",
+            "sample": "Practical Malware Analysis Lab 21-01.exe_",
+            "freeze": "pma21-01-exe.frz",
+            "explanation": "PE 64-bit EXE. Covers amd64 disassembly distinct from the 32-bit PE fixtures above.",
+            "generated_at_commit": "cd07bd230e831cb216450aec98859ae1dc6b16ff"
+        },
+        {
+            "name": "7351f-elf",
+            "sample": "7351f8a40c5450557b24622417fc478d.elf_",
+            "freeze": "7351f-elf.frz",
+            "explanation": "ELF binary via the viv backend. Exercises the ELF loader plus OS/arch detection for non-PE samples.",
+            "generated_at_commit": "cd07bd230e831cb216450aec98859ae1dc6b16ff"
+        },
+        {
+            "name": "1c444-dotnet",
+            "sample": "dotnet/1c444ebeba24dcba8628b7dfe5fec7c6.exe_",
+            "freeze": "1c444-dotnet.frz",
+            "explanation": "Small .NET assembly. Exercises the dotnet backend (dnfile/dotnetfile), which is a completely separate extraction pipeline from viv.",
+            "generated_at_commit": "cd07bd230e831cb216450aec98859ae1dc6b16ff"
+        },
+        {
+            "name": "mimikatz-exe-ida",
+            "sample": "mimikatz.exe_",
+            "freeze": "mimikatz-exe-ida.frz",
+            "backend": "ida",
+            "explanation": "Mimikatz via idalib. Exercises the IDA backend against the same sample as mimikatz-exe (viv), enabling cross-backend comparison.",
+            "generated_at_commit": "dfb34f06a0826c2445a1618530d0f83566b72f7f"
+        }
+    ]
+}


### PR DESCRIPTION
The manifest was accidentally omitted from 6d39e53 (the commit that added the .frz fixtures).  Without it, test_feature_snapshots.py crashes during collection with FileNotFoundError.

Also un-ignore this specific .json file in .gitignore (*.json is blanket-ignored in this repo).